### PR TITLE
Lua syntax highlighting for GitHub.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.p8 linguist-language=Lua


### PR DESCRIPTION
Now that the python build script is merged GitHub seems to think this is a Python repository. By including a .gitattributes file we can make all the .p8 files show up as Lua (and we get syntax highlighting).

![screenshot from 2018-03-31 22-46-35](https://user-images.githubusercontent.com/13558253/38169343-b9bd890a-3535-11e8-9edf-8c0e6d640e13.png)
